### PR TITLE
fix: Remove preview property from interface definition (v1.0.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.6] - 2025-07-16
+
+### Fixed
+- Removed unnecessary preview property from interface definition
+  - The preview property was causing display issues
+  - Interface now relies on default Directus preview generation
+
 ## [1.0.5] - 2025-07-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-expandable-blocks",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "M2A interface with inline expandable editing for Directus",
   "author": "Christopher Schwarz <christopher@neugebauerschwarz.com>",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,5 @@ export default defineInterface({
       }
     }
   ];
-  },
-  preview: '<div>Expandable Blocks</div>'
-
+  }
 });


### PR DESCRIPTION
This PR removes the unnecessary `preview` property from the expandable-blocks interface definition that was causing display issues in Directus