### PR TITLE
Fix: Enable deletion without API and improve UX (Issue #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,15 @@ Unlike other block editors, this extension **works directly with Directus' nativ
 - ⚠️ **Permission Indicators** - Visual feedback for restricted actions
 - 🛡️ **Security** - Built-in validation and permission checks
 
-#### **Usage Tracking & References** 🚀 *(Killer Feature)*
+#### **Usage Tracking & References** 🚀 *(Requires API Extension)*
 - 🔍 **Reference Detection** - Instantly see ALL places where an item is used across your entire Directus instance
 - 📍 **Cross-Collection References** - Track usage across different collections and relationships
 - 🔗 **Deep Links** - Navigate directly to parent items with one click
 - ⚠️ **Usage Warnings** - Get alerts before deleting items that are referenced elsewhere
 - 📊 **Usage Paths** - Visual breadcrumbs showing complete relationship chains
 - 🎯 **Smart Prevention** - Prevents accidental deletion of referenced content
+
+> **Note:** These features require the optional [API extension](https://www.npmjs.com/package/directus-extension-expandable-blocks-api) to be installed.
 
 #### **Inline Editing**
 - ✏️ **Edit Drawer** - Edit items without leaving the interface
@@ -139,13 +141,21 @@ Unlike other block editors, this extension **works directly with Directus' nativ
 ### Via NPM (Recommended)
 
 ```bash
+# Install the interface extension
 npm install directus-extension-expandable-blocks
+
+# Optional: Install the API extension for advanced usage tracking
+npm install directus-extension-expandable-blocks-api
 ```
 
 ### Via pnpm
 
 ```bash
+# Install the interface extension
 pnpm add directus-extension-expandable-blocks
+
+# Optional: Install the API extension for advanced usage tracking
+pnpm add directus-extension-expandable-blocks-api
 ```
 
 ### Manual Installation
@@ -153,12 +163,31 @@ pnpm add directus-extension-expandable-blocks
 1. Download the latest release from [GitHub Releases](https://github.com/smartlabsAT/directus-expandable-blocks/releases)
 2. Extract to your Directus `extensions/` directory
 3. Restart Directus
+4. **Optional**: Install the [API extension](https://github.com/smartlabsAT/directus-expandable-blocks-api) for usage tracking
 
 ### Docker Installation
 
 ```dockerfile
+# Install the interface extension
 RUN npm install directus-extension-expandable-blocks
+
+# Optional: Install the API extension for advanced usage tracking
+RUN npm install directus-extension-expandable-blocks-api
 ```
+
+### 📝 Important Note About the API Extension
+
+**The API extension is now a separate, optional package.** The core Expandable Blocks interface works perfectly without it, using Directus' native API for all standard operations.
+
+#### When to install the API extension:
+- ✅ You want to see where items are used before deleting them
+- ✅ You need to track references across M2A relationships
+- ✅ You want protection against accidentally deleting referenced content
+
+#### The interface works without the API extension:
+- ✅ All core features (editing, sorting, adding blocks) work normally
+- ✅ Uses native Directus API for all operations
+- ⚠️ Cannot verify item usage before deletion (shows warning instead)
 
 ## 🚀 Usage
 

--- a/src/components/BlockHeader.vue
+++ b/src/components/BlockHeader.vue
@@ -66,13 +66,13 @@
       —
     </v-chip>
     <v-chip
-      v-else-if="(usageData?.externalCount > 0) || (usageCount && usageCount > 0)"
+      v-else-if="(usageData?.externalCount > 0) || (usageData?.internalCount > 0) || (usageCount && usageCount > 0)"
       x-small
       class="usage-indicator"
       v-tooltip="usageTooltip"
     >
       <v-icon name="link" x-small />
-      {{ usageData?.externalCount ?? usageCount }}
+      {{ usageData ? (usageData.externalCount + usageData.internalCount) : usageCount }}
     </v-chip>
     <div
       v-else-if="hasAnyUsageIndicator"

--- a/src/components/DeleteConfirmationDialog.vue
+++ b/src/components/DeleteConfirmationDialog.vue
@@ -76,9 +76,20 @@
             <p>{{ collectionName || 'Unknown' }}</p>
           </div>
 
+          <!-- Cannot verify usage warning -->
+          <v-notice
+            v-if="usageInfo.hasUncheckedUsage"
+            type="warning"
+            icon="warning"
+          >
+            <strong>Cannot verify item usage</strong>
+            <p>This item might be used in other locations. Deleting it could break references elsewhere in your content.</p>
+            <p style="margin-top: 8px;">For safe deletion with usage checking, please install the <code>expandable-blocks-api</code> extension.</p>
+          </v-notice>
+
           <!-- Multiple Usage Warning -->
           <v-notice
-            v-if="!(usageInfo.totalCount === 0 || (usageInfo.totalCount === 1 && usageInfo.currentPageUsage))"
+            v-else-if="!(usageInfo.totalCount === 0 || (usageInfo.totalCount === 1 && usageInfo.currentPageUsage))"
             type="warning"
             icon="warning"
           >
@@ -134,7 +145,7 @@
           </div>
 
           <!-- Deletion Options -->
-          <div v-if="canProceed" class="deletion-options">
+          <div v-if="usageInfo.canDelete || usageInfo.hasUncheckedUsage" class="deletion-options">
             <v-divider />
             <h4>Choose action:</h4>
             <div class="action-options">
@@ -166,6 +177,17 @@
                     <p>Remove content from database</p>
                   </div>
                 </div>
+              </label>
+            </div>
+            
+            <!-- Risk Acknowledgment Checkbox when usage cannot be verified and delete is selected -->
+            <div v-if="usageInfo.hasUncheckedUsage && deleteContent" class="risk-acknowledgment-section">
+              <label class="risk-checkbox">
+                <input
+                  type="checkbox"
+                  v-model="acknowledgeRisk"
+                />
+                <span>I understand the risk and want to delete this item anyway</span>
               </label>
             </div>
           </div>
@@ -249,6 +271,7 @@ const emit = defineEmits<{
 const deleteContent = ref(false);
 const selectedLocations = ref<string[]>([]);
 const selectAll = ref(false);
+const acknowledgeRisk = ref(false);
 
 // Reset state when dialog opens
 watch(() => props.modelValue, (isOpen) => {
@@ -256,6 +279,7 @@ watch(() => props.modelValue, (isOpen) => {
     deleteContent.value = false;
     selectedLocations.value = [];
     selectAll.value = false;
+    acknowledgeRisk.value = false;
     
     // Auto-select current page
     if (props.currentPageId && props.usageInfo) {
@@ -274,6 +298,12 @@ const canProceed = computed(() => {
   if (!props.usageInfo) return false;
   if (props.loading) return false;
   
+  // If usage couldn't be verified and user wants to delete permanently,
+  // they must acknowledge the risk
+  if (props.usageInfo.hasUncheckedUsage && deleteContent.value) {
+    return acknowledgeRisk.value;
+  }
+  
   // Can proceed if no usage or only current page
   if (props.usageInfo.canDelete) return true;
   
@@ -289,6 +319,10 @@ const confirmButtonText = computed(() => {
   if (!props.usageInfo) return 'Confirm';
   
   if (deleteContent.value) {
+    // Show special text when deleting with unchecked usage
+    if (props.usageInfo.hasUncheckedUsage) {
+      return 'Delete at Own Risk';
+    }
     return 'Delete Permanently';
   }
   
@@ -638,5 +672,39 @@ function handleConfirm() {
   margin-top: 8px;
   margin-bottom: 0;
   font-size: 13px;
+}
+
+.risk-acknowledgment-section {
+  margin-top: 12px;
+}
+
+.risk-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 12px;
+  margin-top: 12px;
+  background: var(--warning-10);
+  border: 2px solid var(--warning-25);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.risk-checkbox:hover {
+  background: var(--warning-15);
+  border-color: var(--warning);
+}
+
+.risk-checkbox input[type="checkbox"] {
+  margin-top: 2px;
+  cursor: pointer;
+}
+
+.risk-checkbox span {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--warning);
 }
 </style>

--- a/src/components/DeleteConfirmationDialog.vue
+++ b/src/components/DeleteConfirmationDialog.vue
@@ -82,70 +82,15 @@
             type="warning"
             icon="warning"
           >
-            <strong>Cannot verify item usage</strong>
-            <p>This item might be used in other locations. Deleting it could break references elsewhere in your content.</p>
-            <p style="margin-top: 8px;">For safe deletion with usage checking, please install the <code>expandable-blocks-api</code> extension.</p>
+            <div>
+              <strong style="display: block; margin-bottom: 8px;">Cannot verify item usage</strong>
+              <p style="margin: 0;">For safe deletion with usage checking, please install the <code>expandable-blocks-api</code> extension.</p>
+            </div>
           </v-notice>
 
-          <!-- Multiple Usage Warning -->
-          <v-notice
-            v-else-if="!(usageInfo.totalCount === 0 || (usageInfo.totalCount === 1 && usageInfo.currentPageUsage))"
-            type="warning"
-            icon="warning"
-          >
-            This item cannot be permanently deleted because it is used in {{ usageInfo.totalCount - (usageInfo.currentPageUsage ? 1 : 0) }} other {{ (usageInfo.totalCount - (usageInfo.currentPageUsage ? 1 : 0)) === 1 ? 'location' : 'locations' }}. You can only unassign it from this page.
-          </v-notice>
 
-          <!-- Usage Details - only show when item is used in multiple places or other locations -->
-          <div v-if="usageInfo.locations && usageInfo.locations.length > 0 && !(usageInfo.totalCount === 1 && usageInfo.currentPageUsage)">
-            <div class="usage-summary">
-              <v-icon name="link" small />
-              <strong>Used in {{ usageInfo.totalCount }} {{ usageInfo.totalCount === 1 ? 'location' : 'locations' }}:</strong>
-            </div>
-
-            <!-- Usage locations always visible with links -->
-            <div class="location-list">
-              <div
-                v-for="location in usageInfo.locations"
-                :key="`${location.collection}-${location.id}`"
-                class="location-item"
-                :class="{ 'current-page': location.id === currentPageId }"
-              >
-                <v-icon
-                  :name="getCollectionIcon(location.collection)"
-                  class="location-icon"
-                  small
-                />
-                <div class="location-info">
-                  <span class="location-title">
-                    {{ location.title || `${location.collection} #${location.id}` }}
-                  </span>
-                  <a
-                    :href="`/admin/content/${location.collection}/${location.id}`"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="location-link"
-                    @click.stop
-                  >
-                    <v-icon
-                      name="open_in_new"
-                      small
-                    />
-                  </a>
-                  <v-chip
-                    v-if="location.id === currentPageId"
-                    x-small
-                    outlined
-                  >
-                    This Page
-                  </v-chip>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Deletion Options -->
-          <div v-if="usageInfo.canDelete || usageInfo.hasUncheckedUsage" class="deletion-options">
+          <!-- Deletion Options - Always show if we have usage info -->
+          <div v-if="usageInfo" class="deletion-options">
             <v-divider />
             <h4>Choose action:</h4>
             <div class="action-options">
@@ -178,6 +123,79 @@
                   </div>
                 </div>
               </label>
+            </div>
+            
+            <!-- Usage Details - only show when delete is selected and item is used elsewhere -->
+            <div v-if="deleteContent && !usageInfo.hasUncheckedUsage && usageInfo.locations && usageInfo.locations.length > 0 && !(usageInfo.totalCount === 1 && usageInfo.currentPageUsage)">
+              <!-- Usage Warning -->
+              <v-notice
+                type="danger"
+                icon="warning"
+                style="margin-top: 16px;"
+              >
+                <div>
+                  <strong style="display: block;">This item is used in {{ usageInfo.totalCount - (usageInfo.currentPageUsage ? 1 : 0) }} other {{ (usageInfo.totalCount - (usageInfo.currentPageUsage ? 1 : 0)) === 1 ? 'location' : 'locations' }}</strong>
+                  <span style="display: block; margin-top: 4px;">To delete this item permanently, you must acknowledge each usage location below.</span>
+                </div>
+              </v-notice>
+
+              <div class="usage-summary">
+                <v-icon name="link" small />
+                <strong>Used in {{ usageInfo.totalCount }} {{ usageInfo.totalCount === 1 ? 'location' : 'locations' }}:</strong>
+              </div>
+
+              <!-- Usage locations with acknowledgment checkboxes -->
+              <div class="location-list-with-checks">
+                <div
+                  v-for="(location, index) in usageInfo.locations"
+                  :key="getLocationKey(location, index)"
+                  class="location-item-with-check"
+                  :class="{ 
+                    'current-page': location.id === currentPageId,
+                    'acknowledged': acknowledgedLocations.has(getLocationKey(location, index))
+                  }"
+                >
+                  <!-- Skip checkbox for current page -->
+                  <input
+                    v-if="location.id !== currentPageId"
+                    type="checkbox"
+                    :checked="acknowledgedLocations.has(getLocationKey(location, index))"
+                    @change="toggleLocationAcknowledgment(getLocationKey(location, index))"
+                    class="location-checkbox"
+                  />
+                  <div v-else class="checkbox-spacer"></div>
+                  
+                  <v-icon
+                    :name="getCollectionIcon(location.collection)"
+                    class="location-icon"
+                    small
+                  />
+                  <div class="location-info">
+                    <span class="location-title">
+                      {{ location.title || `${location.collection} #${location.id}` }}
+                    </span>
+                    <a
+                      :href="`/admin/content/${location.collection}/${location.id}`"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="location-link"
+                      @click.stop
+                    >
+                      <v-icon
+                        name="open_in_new"
+                        small
+                      />
+                    </a>
+                    <v-chip
+                      v-if="location.id === currentPageId"
+                      x-small
+                      outlined
+                    >
+                      This Page
+                    </v-chip>
+                  </div>
+                </div>
+              </div>
             </div>
             
             <!-- Risk Acknowledgment Checkbox when usage cannot be verified and delete is selected -->
@@ -272,6 +290,7 @@ const deleteContent = ref(false);
 const selectedLocations = ref<string[]>([]);
 const selectAll = ref(false);
 const acknowledgeRisk = ref(false);
+const acknowledgedLocations = ref<Set<string>>(new Set());
 
 // Reset state when dialog opens
 watch(() => props.modelValue, (isOpen) => {
@@ -280,6 +299,7 @@ watch(() => props.modelValue, (isOpen) => {
     selectedLocations.value = [];
     selectAll.value = false;
     acknowledgeRisk.value = false;
+    acknowledgedLocations.value = new Set();
     
     // Auto-select current page
     if (props.currentPageId && props.usageInfo) {
@@ -294,6 +314,23 @@ watch(() => props.modelValue, (isOpen) => {
 });
 
 // Computed properties
+const nonCurrentPageLocations = computed(() => {
+  if (!props.usageInfo?.locations) return [];
+  return props.usageInfo.locations.filter(loc => loc.id !== props.currentPageId);
+});
+
+const allAcknowledged = computed(() => {
+  if (!props.usageInfo?.locations) return false;
+  
+  const nonCurrentLocations = props.usageInfo.locations.filter(loc => loc.id !== props.currentPageId);
+  if (nonCurrentLocations.length === 0) return false;
+  
+  return nonCurrentLocations.every((location, index) => {
+    const fullIndex = props.usageInfo!.locations.indexOf(location);
+    return acknowledgedLocations.value.has(getLocationKey(location, fullIndex));
+  });
+});
+
 const canProceed = computed(() => {
   if (!props.usageInfo) return false;
   if (props.loading) return false;
@@ -304,13 +341,17 @@ const canProceed = computed(() => {
     return acknowledgeRisk.value;
   }
   
+  // If there are external usages and user wants to delete permanently,
+  // all locations must be acknowledged
+  if (!props.usageInfo.canDelete && deleteContent.value) {
+    return allAcknowledged.value;
+  }
+  
   // Can proceed if no usage or only current page
   if (props.usageInfo.canDelete) return true;
   
-  // Can proceed if force delete is allowed and locations are selected
-  if (props.allowForceDelete && selectedLocations.value.length > 0) {
-    return true;
-  }
+  // Can proceed with unassign (not delete)
+  if (!deleteContent.value) return true;
   
   return false;
 });
@@ -323,6 +364,10 @@ const confirmButtonText = computed(() => {
     if (props.usageInfo.hasUncheckedUsage) {
       return 'Delete at Own Risk';
     }
+    // Show special text when forced deletion with acknowledged locations
+    if (!props.usageInfo.canDelete && allAcknowledged.value) {
+      return 'Force Delete';
+    }
     return 'Delete Permanently';
   }
   
@@ -330,6 +375,27 @@ const confirmButtonText = computed(() => {
 });
 
 // Methods
+function getLocationKey(location: any, index: number): string {
+  // Use junction_id if available for uniqueness, otherwise fall back to index
+  if (location.junction_id) {
+    return `${location.collection}:${location.id}:${location.junction_id}`;
+  }
+  // Fallback to index-based key if no junction_id
+  return `${location.collection}:${location.id}:${index}`;
+}
+
+function toggleLocationAcknowledgment(locationKey: string) {
+  const newSet = new Set(acknowledgedLocations.value);
+  if (newSet.has(locationKey)) {
+    newSet.delete(locationKey);
+  } else {
+    newSet.add(locationKey);
+  }
+  acknowledgedLocations.value = newSet;
+}
+
+// Removed acknowledgeAll function - users must manually check each item
+
 function getStatusLabel(status: string): string {
   const statusLabels: Record<string, string> = {
     'published': 'Published',
@@ -370,6 +436,28 @@ function handleConfirm() {
 </script>
 
 <style scoped>
+/* Dialog Content Scrolling */
+:deep(.v-card) {
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+}
+
+:deep(.v-card-title) {
+  flex-shrink: 0;
+}
+
+:deep(.v-card-text) {
+  flex: 1;
+  overflow-y: auto;
+  max-height: calc(90vh - 200px); /* Account for header and footer */
+}
+
+:deep(.v-card-actions) {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-subdued);
+}
+
 .loading-container {
   display: flex;
   flex-direction: column;
@@ -520,55 +608,76 @@ function handleConfirm() {
 }
 
 
-.location-list {
-  max-height: 200px;
+.location-list-with-checks {
+  max-height: 400px; /* Increased from 300px for better visibility */
   overflow-y: auto;
   overflow-x: hidden;
-  border: 1px solid var(--border-subdued);
+  border: 2px solid var(--danger-25);
   border-radius: var(--border-radius);
   background: var(--background-normal);
   scroll-behavior: smooth;
 }
 
 /* Custom scrollbar styling for better UX */
-.location-list::-webkit-scrollbar {
+.location-list-with-checks::-webkit-scrollbar {
   width: 8px;
 }
 
-.location-list::-webkit-scrollbar-track {
+.location-list-with-checks::-webkit-scrollbar-track {
   background: var(--background-subdued);
   border-radius: var(--border-radius);
 }
 
-.location-list::-webkit-scrollbar-thumb {
+.location-list-with-checks::-webkit-scrollbar-thumb {
   background: var(--border-normal);
   border-radius: var(--border-radius);
 }
 
-.location-list::-webkit-scrollbar-thumb:hover {
+.location-list-with-checks::-webkit-scrollbar-thumb:hover {
   background: var(--border-normal-alt);
 }
 
-.location-item {
+.location-item-with-check {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 12px;
+  gap: 12px;
+  padding: 12px 16px;
   border-bottom: 1px solid var(--border-subdued);
-  transition: background-color 0.2s;
+  transition: all 0.2s;
 }
 
-.location-item:last-child {
+.location-item-with-check:last-of-type {
   border-bottom: none;
 }
 
-.location-item:hover {
+.location-item-with-check:hover {
   background: var(--background-highlight);
 }
 
-.location-item.current-page {
-  background: var(--primary-10);
+.location-item-with-check.current-page {
+  opacity: 0.7;
 }
+
+.location-item-with-check.acknowledged .location-title {
+  text-decoration: line-through;
+  opacity: 0.7;
+  color: var(--foreground-subdued);
+}
+
+.location-checkbox {
+  width: 18px;
+  height: 18px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.checkbox-spacer {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+}
+
+/* Removed .acknowledge-all styles - button was removed */
 
 .location-icon {
   color: var(--foreground-subdued);
@@ -706,5 +815,13 @@ function handleConfirm() {
   font-size: 14px;
   font-weight: 500;
   color: var(--warning);
+}
+
+.acknowledgment-warning {
+  margin-top: 12px;
+}
+
+.acknowledgment-warning .v-notice {
+  margin: 0;
 }
 </style>

--- a/src/composables/useExpandableBlocks.ts
+++ b/src/composables/useExpandableBlocks.ts
@@ -472,11 +472,17 @@ export function useExpandableBlocks(
             if (item.usage_summary?.total_count > 0) {
               const allUsageLocations = Array.isArray(item.usage_locations) ? item.usage_locations : [];
               
-              // Filter out locations from current parent
-              // Only filter if we have a valid currentParentId
+              // Count locations on current page and external pages
               let externalLocations = allUsageLocations;
+              let locationsOnCurrentPage = 0;
+              
               if (currentParentId !== undefined && currentParentId !== null && currentParentId !== '') {
                 const currentParentIdStr = String(currentParentId);
+                // Count how many times it's used on current page
+                locationsOnCurrentPage = allUsageLocations.filter((location: any) => 
+                  String(location.id) === currentParentIdStr
+                ).length;
+                // External locations are those NOT on current page
                 externalLocations = allUsageLocations.filter((location: any) => 
                   String(location.id) !== currentParentIdStr
                 );
@@ -484,19 +490,20 @@ export function useExpandableBlocks(
               
               // Calculate counts
               const externalCount = externalLocations.length;
-              const internalCount = allUsageLocations.length - externalCount;
+              // Internal count is how many MORE times it's used on this page (minus the current one)
+              const internalCount = locationsOnCurrentPage > 0 ? locationsOnCurrentPage - 1 : 0;
               
-              // Only store if there are external usages
-              if (externalCount > 0) {
+              // Store usage info if there are any usages (external OR internal)
+              if (externalCount > 0 || internalCount > 0) {
                 const key = `${collection}:${item.id}`;
                 // Create plain object without Vue reactivity proxies
                 const usageInfo = {
-                  usageCount: externalCount, // Only count external
+                  usageCount: externalCount + internalCount, // Total visible count
                   externalCount,
                   internalCount,
                   externalLocations,
                   usageSummary: {
-                    total_count: externalCount,
+                    total_count: item.usage_summary?.total_count || 0, // Keep original total
                     by_collection: item.usage_summary?.by_collection || {},
                     by_status: item.usage_summary?.by_status || {}
                   }

--- a/src/services/RelationChecker.ts
+++ b/src/services/RelationChecker.ts
@@ -15,6 +15,7 @@ export interface ItemUsageInfo {
   currentPageUsage: boolean;
   locations: ItemUsageLocation[];
   canDelete: boolean;
+  hasUncheckedUsage?: boolean;  // Indicates usage couldn't be verified
 }
 
 interface DirectusAPI {
@@ -108,14 +109,15 @@ export class RelationChecker {
       // Fallback: If custom API is not available or failed, try native approach
       logDebug('Custom API not available, using native API fallback', { collection, itemId });
       
-      // If relation checking is not available at all, return permissive defaults
+      // If relation checking is not available at all, return with warning flag
       if (!this.isRelationCheckingAvailable) {
-        logDebug('Relation checking not available, returning permissive defaults', { collection, itemId });
+        logDebug('Relation checking not available, returning with warning flag', { collection, itemId });
         return {
           totalCount: 0,
           currentPageUsage: false,
           locations: [],
-          canDelete: true // Allow deletion when we can't check (will show warning in UI)
+          canDelete: true, // Allow deletion but with warning
+          hasUncheckedUsage: true // Flag that usage couldn't be verified
         };
       }
 
@@ -188,12 +190,13 @@ export class RelationChecker {
     } catch (error) {
       logError('Failed to check item usage', error, { collection, itemId });
       
-      // In case of error, be permissive to not block users
+      // In case of error, be permissive to not block users but flag as unchecked
       return {
         totalCount: 0,
         currentPageUsage: false,
         locations: [],
-        canDelete: true // Allow deletion on error (UI will show warning)
+        canDelete: true, // Allow deletion on error 
+        hasUncheckedUsage: true // Flag that usage couldn't be verified due to error
       };
     }
   }
@@ -204,16 +207,17 @@ export class RelationChecker {
   async checkMultipleItemsUsage(items: Array<{ collection: string; id: string | number }>): Promise<Map<string, ItemUsageInfo>> {
     const results = new Map<string, ItemUsageInfo>();
 
-    // If relation checking is not available, return safe defaults for all items
+    // If relation checking is not available, return with warning flag for all items
     if (!this.isRelationCheckingAvailable) {
-      logDebug('Relation checking not available, returning safe defaults for all items');
+      logDebug('Relation checking not available, returning with warning flag for all items');
       for (const item of items) {
         const key = `${item.collection}:${item.id}`;
         results.set(key, {
           totalCount: 0,
           currentPageUsage: false,
           locations: [],
-          canDelete: false // Be conservative
+          canDelete: true, // Allow deletion but with warning
+          hasUncheckedUsage: true // Flag that usage couldn't be verified
         });
       }
       return results;

--- a/src/services/RelationChecker.ts
+++ b/src/services/RelationChecker.ts
@@ -8,6 +8,7 @@ export interface ItemUsageLocation {
   field: string;
   title?: string;
   status?: string;
+  junction_id?: string | number;  // Unique identifier for each usage
 }
 
 export interface ItemUsageInfo {
@@ -67,38 +68,44 @@ export class RelationChecker {
         
         // Try to get usage info from custom API
         const usageInfo = await this.apiClient.getItemUsage(collection, itemId);
+        logDebug('Raw usage info from API', usageInfo);
         
-        if (usageInfo) {
+        if (usageInfo !== null) {
           // Process the usage info from custom API
           const locations: ItemUsageLocation[] = [];
           let currentPageUsage = false;
           
           // Process locations from the custom API response
-          // Filter out current page from locations
+          // Keep ALL locations, just mark which ones are on current page
           if (usageInfo.locations && Array.isArray(usageInfo.locations)) {
             for (const location of usageInfo.locations) {
               // Check if this is the current page
               if (this.currentPageId && String(location.id) === String(this.currentPageId)) {
                 currentPageUsage = true;
-                // Skip adding this location to the list
-                continue;
               }
               
+              // Add ALL locations to the list (including current page)
               locations.push({
                 collection: location.collection,
                 id: location.id,
                 field: location.field || 'unknown',
                 title: location.title || `${location.collection} #${location.id}`,
-                status: location.status
+                status: location.status,
+                junction_id: location.junction_id  // Include junction_id for uniqueness
               });
             }
           }
           
-          // Calculate real external count (excluding current page)
-          const externalCount = locations.length;
+          // Get total count from API or calculate from locations
+          const totalCount = usageInfo.total_count || locations.length;
+          
+          // Count external locations (not on current page)
+          const externalCount = locations.filter(loc => 
+            !this.currentPageId || String(loc.id) !== String(this.currentPageId)
+          ).length;
           
           return {
-            totalCount: externalCount, // Only count external locations
+            totalCount,
             currentPageUsage,
             locations,
             canDelete: externalCount === 0 // Can delete if no external usage
@@ -121,7 +128,8 @@ export class RelationChecker {
         };
       }
 
-      // Use native API client to get item data with relations
+      // Try to use native API, but it won't have usage_locations or usage_summary
+      // These are custom fields only available through the expandable-blocks-api
       const items = await this.apiClient.loadItemsWithRelations(
         collection,
         [itemId],
@@ -136,14 +144,15 @@ export class RelationChecker {
           totalCount: 0,
           currentPageUsage: false,
           locations: [],
-          canDelete: true
+          canDelete: true,
+          hasUncheckedUsage: true // Can't verify without data
         };
       }
 
       const locations: ItemUsageLocation[] = [];
       let currentPageUsage = false;
 
-      // Process usage locations if available
+      // Process usage locations if available (only with custom API)
       if (itemData.usage_locations && Array.isArray(itemData.usage_locations)) {
         // Use a Set to track unique locations
         const uniqueLocationKeys = new Set<string>();
@@ -161,21 +170,40 @@ export class RelationChecker {
           // Check if this is the current page (compare as strings)
           if (this.currentPageId && String(location.id) === String(this.currentPageId)) {
             currentPageUsage = true;
-            // Skip adding this location to the list
-            continue;
           }
           
-          // Get additional info about the location
+          // Add ALL locations (including current page)
           const locationInfo: ItemUsageLocation = {
             collection: location.collection,
             id: location.id,
             field: location.field || 'unknown',
             title: location.title || `${location.collection} #${location.id}`,
-            status: location.status
+            status: location.status,
+            junction_id: location.junction_id  // Include junction_id if available
           };
 
           locations.push(locationInfo);
         }
+      }
+
+      // Check if we have usage data (only available with custom API)
+      const hasUsageData = itemData.usage_summary || itemData.usage_locations;
+      
+      if (!hasUsageData) {
+        // Native API doesn't provide usage data, return with warning
+        logDebug('No usage data available (native API), returning with warning flag', { collection, itemId });
+        logDebug('Item data received:', { 
+          hasUsageSummary: !!itemData.usage_summary,
+          hasUsageLocations: !!itemData.usage_locations,
+          keys: Object.keys(itemData)
+        });
+        return {
+          totalCount: 0,
+          currentPageUsage: false,
+          locations: [],
+          canDelete: true,
+          hasUncheckedUsage: true // Native API can't provide usage info
+        };
       }
 
       const totalCount = itemData.usage_summary?.total_count || 0;

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -6,7 +6,7 @@
  */
 
 import type { AxiosInstance } from 'axios';
-import { logError, logWarn } from '../utils/logger-wrapper';
+import { logDebug, logError, logWarn } from '../utils/logger-wrapper';
 import { createApiAvailabilityChecker } from './api-availability-checker';
 import type { ApiAvailabilityChecker, FeatureSet } from './api-availability-checker';
 import type {
@@ -172,6 +172,15 @@ export class DirectusApiClient implements IDirectusApiClient {
           );
           
           const items = response.data.data || [];
+          
+          // Debug: Log what we got from the API
+          if (items.length > 0 && items[0].usage_locations) {
+            logDebug('API returned usage data', {
+              itemId: ids[0],
+              usageLocations: items[0].usage_locations,
+              usageSummary: items[0].usage_summary
+            });
+          }
           
           // External API provides enhanced data with usage_locations and usage_summary
           return items;
@@ -445,12 +454,14 @@ export class DirectusApiClient implements IDirectusApiClient {
       const items = await this.loadItemsWithRelations(collection, [id]);
       const item = items?.[0];
       
-      if (item?.usage_locations && item?.usage_summary) {
-        // Return in the format expected by RelationChecker
+      // Check if we got an item back from the API
+      if (item) {
+        // Even if usage_locations or usage_summary are missing/empty, 
+        // we should still return a result (the API supports usage tracking)
         return {
           locations: item.usage_locations || [],
           total_count: item.usage_summary?.total_count || 0,
-          can_delete: item.usage_summary?.total_count === 0,
+          can_delete: item.usage_summary?.can_delete !== false, // Default to true if not explicitly false
           usage_locations: item.usage_locations || [],
           usage_summary: item.usage_summary || {}
         };


### PR DESCRIPTION
## 🎯 Summary

This PR addresses Issue #48 and improves the delete confirmation dialog UX when the expandable-blocks-api extension is not installed.

## ✨ Changes

### Core Fixes
- ✅ Enable block deletion when API is not installed (with appropriate warning)
- ✅ Fix reference counting for multiple usages on same page
- ✅ Fix checkbox grouping when same block appears multiple times
- ✅ Add junction_id support for unique usage identification

### UX Improvements
- 📋 Reorganized delete dialog - usage info only shows when "Delete permanently" is selected
- 🎨 Replace green background with text strikethrough for checked items
- 📜 Make dialog scrollable for many references (max-height: 90vh)
- ⚠️ Simplified warning message structure
- ❌ Removed "Acknowledge All" button to prevent accidental confirmations

### Documentation
- 📚 Updated README with API separation instructions
- 📖 Updated Wiki documentation (Installation, Architecture, Changelog)

## 🔧 Technical Details

### API Response Handling
- Fixed `getItemUsage()` to return data even with empty usage_locations
- Added missing `logDebug` import in api-client.ts

### Reference Counting
- Calculate `internalCount` as locations on current page minus one (current instance)
- Show sum of `externalCount + internalCount` in BlockHeader

### Delete Dialog Changes
- Use `junction_id` for unique checkbox identification
- Warning messages moved under action selection
- Dialog content area is scrollable while header/footer stay fixed

## 🧪 Testing

- ✅ Tested deletion without API - shows warning
- ✅ Tested deletion with API - shows usage locations
- ✅ Tested multiple usages on same page - correct counting
- ✅ Tested checkbox individuality - each checkbox works independently
- ✅ Tested scrolling with many references

## 📸 Key Changes

1. **Without API**: Shows "Cannot verify item usage" warning with risk acknowledgment
2. **With API**: Shows detailed usage locations with individual checkboxes
3. **Reference Count**: Now correctly shows "2" when item used 3 times (current + 2 others)

## 🔗 Related Issues

- Fixes #48 - Enable block deletion without expandable-blocks-api
- Fixes #47 - Restore references/usage display (partially)
- Related to #39 - Migration to external API architecture

Ready for review! 🚀