### PR TITLE
Hotfix: Remove axios dependency and fix TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@vitest/coverage-v8": "^1.1.0",
     "@vitest/ui": "^1.1.0",
     "@vue/test-utils": "^2.4.3",
-    "axios": "^1.11.0",
     "dotenv": "^17.2.1",
     "eslint": "^9.32.0",
     "eslint-plugin-vue": "^10.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,9 +54,6 @@ importers:
       '@vue/test-utils':
         specifier: ^2.4.3
         version: 2.4.6
-      axios:
-        specifier: ^1.11.0
-        version: 1.11.0
       dotenv:
         specifier: ^17.2.1
         version: 17.2.1
@@ -1282,9 +1279,6 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.11.0:
-    resolution: {integrity: sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==}
-
   axios@1.7.3:
     resolution: {integrity: sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==}
 
@@ -1782,10 +1776,6 @@ packages:
 
   form-data@4.0.3:
     resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
-    engines: {node: '>= 6'}
-
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   fs-extra@10.1.0:
@@ -4306,14 +4296,6 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.11.0:
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.4
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-
   axios@1.7.3:
     dependencies:
       follow-redirects: 1.15.9
@@ -4909,14 +4891,6 @@ snapshots:
       signal-exit: 4.1.0
 
   form-data@4.0.3:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-
-  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8

--- a/src/services/api-availability-checker.ts
+++ b/src/services/api-availability-checker.ts
@@ -5,8 +5,8 @@
  * for graceful degradation when custom API is not available.
  */
 
-import type { AxiosInstance } from 'axios';
 import { logDebug, logError, logWarn } from '../utils/logger-wrapper';
+import type { DirectusApiInstance } from './api-client.types';
 
 /**
  * Available features based on API availability
@@ -41,13 +41,13 @@ interface ApiEndpoints {
 
 
 export class ApiAvailabilityChecker {
-  private api: AxiosInstance;
+  private api: DirectusApiInstance;
   private endpoints: ApiEndpoints;
   private customApiAvailable: boolean | null = null;
   private nativeApiAvailable: boolean | null = null;
   private hasChecked: boolean = false;
   
-  constructor(api: AxiosInstance) {
+  constructor(api: DirectusApiInstance) {
     this.api = api;
     this.endpoints = {
       custom: '/expandable-blocks-api/health',
@@ -74,7 +74,7 @@ export class ApiAvailabilityChecker {
       // We use a lightweight endpoint that should respond quickly
       const response = await this.api.get(this.endpoints.custom, {
         timeout: 3000, // 3 second timeout
-        validateStatus: (status) => status === 200 || status === 404
+        validateStatus: (status: number) => status === 200 || status === 404
       });
       
       const available = response.status === 200;
@@ -122,7 +122,7 @@ export class ApiAvailabilityChecker {
       // We do a simple check just to be sure
       const response = await this.api.get(this.endpoints.native, {
         timeout: 3000,
-        validateStatus: (status) => status === 200
+        validateStatus: (status: number) => status === 200
       });
       
       const available = response.status === 200;
@@ -203,6 +203,6 @@ export class ApiAvailabilityChecker {
 /**
  * Factory function to create availability checker
  */
-export function createApiAvailabilityChecker(api: AxiosInstance): ApiAvailabilityChecker {
+export function createApiAvailabilityChecker(api: DirectusApiInstance): ApiAvailabilityChecker {
   return new ApiAvailabilityChecker(api);
 }

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -5,7 +5,6 @@
  * This replaces the custom API extension with direct Directus API calls.
  */
 
-import type { AxiosInstance } from 'axios';
 import { logDebug, logError, logWarn } from '../utils/logger-wrapper';
 import { createApiAvailabilityChecker } from './api-availability-checker';
 import type { ApiAvailabilityChecker, FeatureSet } from './api-availability-checker';
@@ -20,18 +19,20 @@ import type {
   PermissionResult,
   ApiError,
   TranslationInfo,
-  ItemUsageResult
+  ItemUsageResult,
+  DirectusApiInstance,
+  ApiResponse
 } from './api-client.types';
 
 /**
  * Main Directus API Client implementation
  */
 export class DirectusApiClient implements IDirectusApiClient {
-  private api: AxiosInstance;
+  private api: DirectusApiInstance;
   private config: ApiClientConfig;
   private availabilityChecker: ApiAvailabilityChecker;
 
-  constructor(api: AxiosInstance, config: ApiClientConfig = {}) {
+  constructor(api: DirectusApiInstance, config: ApiClientConfig = {}) {
     this.api = api;
     this.config = {
       retry: true,
@@ -479,7 +480,7 @@ export class DirectusApiClient implements IDirectusApiClient {
   /**
    * Get the raw API instance for direct calls
    */
-  getApi(): AxiosInstance {
+  getApi(): DirectusApiInstance {
     return this.api;
   }
 
@@ -859,7 +860,7 @@ export class DirectusApiClient implements IDirectusApiClient {
  * Factory function to create API client instance
  */
 export function createApiClient(
-  api: AxiosInstance,
+  api: DirectusApiInstance,
   config?: ApiClientConfig
 ): IDirectusApiClient {
   return new DirectusApiClient(api, config);

--- a/src/services/api-client.types.ts
+++ b/src/services/api-client.types.ts
@@ -2,8 +2,23 @@
  * Type definitions for the Directus API Client
  */
 
-import type { AxiosInstance } from 'axios';
 import type { FeatureSet } from './api-availability-checker';
+
+// Define our own API interface instead of using AxiosInstance
+export interface ApiResponse<T = any> {
+  data: T;
+  status: number;
+  statusText: string;
+  headers?: Record<string, any>;
+}
+
+export interface DirectusApiInstance {
+  get<T = any>(url: string, config?: any): Promise<ApiResponse<T>>;
+  post<T = any>(url: string, data?: any, config?: any): Promise<ApiResponse<T>>;
+  patch<T = any>(url: string, data?: any, config?: any): Promise<ApiResponse<T>>;
+  delete<T = any>(url: string, config?: any): Promise<ApiResponse<T>>;
+  request<T = any>(config: any): Promise<ApiResponse<T>>;
+}
 
 /**
  * Search query options
@@ -219,7 +234,7 @@ export interface IDirectusApiClient {
   ): Promise<ItemUsageResult | null>;
 
   // Get raw API instance for direct calls
-  getApi(): AxiosInstance;
+  getApi(): DirectusApiInstance;
   
   // Feature availability
   getAvailableFeatures(): Promise<FeatureSet>;


### PR DESCRIPTION
## Summary
Removes unnecessary axios dependency and replaces with custom interface types to fix CI build failures.

## Problem
- CI was failing due to axios version conflicts
- We don't actually need axios as a direct dependency - it comes from Directus SDK
- TypeScript was having issues with multiple axios versions

## Solution
- Created custom `DirectusApiInstance` interface that matches what we need
- Removed axios from dependencies completely
- Fixed all TypeScript compilation issues
- Added proper type definitions for API responses

## Changes
- ✅ Removed `axios` from package.json
- ✅ Created `DirectusApiInstance` and `ApiResponse` types
- ✅ Updated all files to use custom types instead of AxiosInstance
- ✅ Fixed TypeScript compilation
- ✅ Cleaned up unused dependencies

## Testing
- TypeScript compilation: ✅ Passing
- ESLint: ✅ No errors
- Local build: ✅ Successful

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change