### PR TITLE
chore: remove unused ApiResponse import

### DIFF
--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -20,8 +20,7 @@ import type {
   ApiError,
   TranslationInfo,
   ItemUsageResult,
-  DirectusApiInstance,
-  ApiResponse
+  DirectusApiInstance
 } from './api-client.types';
 
 /**


### PR DESCRIPTION
## Description
Removes unused ApiResponse import from api-client.ts that was left over from the axios removal refactoring.

## Changes
- Remove unused ApiResponse import from api-client.ts

## Type of Change
- [x] Code cleanup (non-functional change)

## Related Issues
- Related to #52 (v1.2.0 release preparation)
- Related to #54 (test fixes)