### PR TITLE
Hotfix: Fix shared component exports for external extensions

### DIFF
--- a/build-types.js
+++ b/build-types.js
@@ -27,7 +27,7 @@ async function buildTypeDefinitions() {
       console.log('✅ Copied shared type definitions to dist/shared/index.d.ts');
     }
     
-    // Create a simple shared module export for Directus compatibility
+    // Create proper shared module exports
     const sharedExportContent = `
 /**
  * Shared ItemSelector components for other extensions
@@ -36,11 +36,27 @@ async function buildTypeDefinitions() {
  * import { useItemSelector, ItemSelectorDrawer } from 'directus-extension-expandable-blocks/shared';
  */
 
-// Re-export everything from the main extension that's needed for sharing
-export * from '../index.js';
+// Export composables
+export { useItemSelector } from '../index.js';
+
+// Export components
+export { 
+  ItemSelectorDrawer,
+  ItemSearchPanel,
+  FieldDisplay,
+  UsagePopover,
+  FieldSettingsMenu,
+  ItemEditDrawer,
+  ItemSelectorTable
+} from '../index.js';
+
+// Export types
+export { 
+  DEFAULT_ITEM_SELECTOR_CONFIG
+} from '../index.js';
 
 // Export version info
-export const SHARED_VERSION = '1.2.0';
+export const SHARED_VERSION = '1.3.1';
 `;
 
     fs.writeFileSync('dist/shared/index.js', sharedExportContent.trim());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-expandable-blocks",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "M2A interface with inline expandable editing for Directus. Provides reusable ItemSelector components for other extensions.",
   "author": "Christopher Schwarz <christopher@neugebauerschwarz.com>",
   "license": "MIT",


### PR DESCRIPTION
## 🐛 Hotfix: Shared Component Exports

### Problem
The shared components (useItemSelector, ItemSelectorDrawer, etc.) were not properly exported in the dist build, causing import errors when other extensions try to use them.

### Solution
- Updated `build-types.js` to properly export named exports from the main index.js
- Version bumped to 1.3.1
- Fixed shared/index.js generation in dist folder

### Testing
After this fix, the following imports work correctly:
```typescript
import { useItemSelector, ItemSelectorDrawer } from 'directus-extension-expandable-blocks/shared';
```

### Impact
- Fixes layout-blocks extension Phase 2 implementation
- Enables other extensions to use the shared ItemSelector components

### Checklist
- [x] Build script updated
- [x] Version bumped to 1.3.1
- [x] Tested with layout-blocks extension
- [x] No breaking changes