### PR TITLE
Hotfix v1.3.2: Export shared components from main index

### DIFF
--- a/build-types.js
+++ b/build-types.js
@@ -56,7 +56,7 @@ export {
 } from '../index.js';
 
 // Export version info
-export const SHARED_VERSION = '1.3.1';
+export const SHARED_VERSION = '1.3.2';
 `;
 
     fs.writeFileSync('dist/shared/index.js', sharedExportContent.trim());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-expandable-blocks",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "M2A interface with inline expandable editing for Directus. Provides reusable ItemSelector components for other extensions.",
   "author": "Christopher Schwarz <christopher@neugebauerschwarz.com>",
   "license": "MIT",

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -1,0 +1,20 @@
+/**
+ * Exports for use by other extensions
+ * This file exports the shared components that other extensions can use
+ */
+
+// Export composables
+export { useItemSelector } from './composables/useItemSelector';
+
+// Export the main component that other extensions need
+export { default as ItemSelectorDrawer } from './components/ItemSelectorDrawer.vue';
+
+// Export types
+export type { 
+  ItemSelectorConfig,
+  TranslationInfo,
+  FieldWithTranslation,
+  LanguageOption
+} from './shared/types';
+
+export { DEFAULT_ITEM_SELECTOR_CONFIG } from './shared/types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { defineInterface } from '@directus/extensions-sdk';
 import InterfaceComponent from './interface.vue';
 
+// Export shared components for use in other extensions
+export * from './exports';
+
 export default defineInterface({
   id: 'expandable-blocks',
   name: 'Expandable Blocks',


### PR DESCRIPTION
Fixes the export issue that prevented other extensions from importing the shared components.

- Added exports.ts to cleanly export shared components
- Main index.js now exports useItemSelector and ItemSelectorDrawer
- Version bumped to 1.3.2

This completes the fix started in v1.3.1.