### PR TITLE
feat: Add tooltips for truncated titles in ItemSelector (v1.3.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-expandable-blocks",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "M2A interface with inline expandable editing for Directus. Provides reusable ItemSelector components for other extensions.",
   "author": "Christopher Schwarz <christopher@neugebauerschwarz.com>",
   "license": "MIT",

--- a/src/components/ItemSelectorTable.vue
+++ b/src/components/ItemSelectorTable.vue
@@ -141,7 +141,10 @@
                   :class="`status-${item.status}`"
                   v-tooltip.top="capitalizeField(item.status)"
               />
-              <span class="item-title">{{ extractItemTitle(item) }}</span>
+              <span 
+                  class="item-title"
+                  v-tooltip.top="extractItemTitle(item)"
+              >{{ extractItemTitle(item) }}</span>
             </div>
             <!-- Update Info -->
             <span v-if="showLastUpdate && item?.date_updated" class="update-info">

--- a/src/shared/components/ItemSelectorTable.vue
+++ b/src/shared/components/ItemSelectorTable.vue
@@ -141,7 +141,10 @@
                   :class="`status-${item.status}`"
                   v-tooltip.top="capitalizeField(item.status)"
               />
-              <span class="item-title">{{ extractItemTitle(item) }}</span>
+              <span 
+                  class="item-title"
+                  v-tooltip.top="extractItemTitle(item)"
+              >{{ extractItemTitle(item) }}</span>
             </div>
             <!-- Update Info -->
             <span v-if="showLastUpdate && item?.date_updated" class="update-info">


### PR DESCRIPTION
## 🚀 Feature: Tooltip Support for Truncated Titles

### Changes
- ✨ Added  directive to  spans in ItemSelectorTable
- 🎯 Shows full title text on hover when titles are truncated with ellipsis
- 🔄 Updated both main and shared components for consistency
- 📦 Version bump to 1.3.3

### Files Changed
- 
- 
-  (version bump)

### User Experience
- **Before**: Long titles were cut off with  and no way to see full text
- **After**: Hover over truncated titles shows complete text in tooltip

### Issue
Closes #60

### Testing
- ✅ Extension builds successfully
- ✅ Both main and shared components updated
- ✅ Tooltip uses Directus native  directive

### Ready for Release
- Version bumped to 1.3.3
- Ready for tagging and npm publish