### PR TITLE
fix: Add Existing button visibility, link mutation, and duplicate prevention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to the Directus Expandable Blocks extension are documented h
 
 ## [Unreleased]
 
+## [1.3.6] - 2026-05-27
+
+### Fixed
+- **Add Existing fallback**: Empty `allowedCollectionsForExisting` now falls back to `allowedCollections` as documented ([#65](https://github.com/smartlabsAT/directus-expandable-blocks/issues/65))
+- **Link mutation**: Linking existing items no longer writes back to the source item on save
+- **Duplicate links**: Same item can no longer be linked multiple times into one record
+
+### Changed
+- **Type safety**: `allowedCollections` / `allowedCollectionsForExisting` refs typed as `CollectionInfo[]` instead of `any[]`
+
 ## [1.3.5] - 2026-05-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ The interface provides extensive configuration grouped into logical sections:
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `collection` | array | `[]` | Collections for new blocks |
-| `allowedCollectionsExisting` | array | `[]` | Collections for existing items |
+| `allowedCollectionsForExisting` | array | Falls back to `collection` | Collections for existing items |
 
 ### Advanced
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "directus-extension-expandable-blocks",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "M2A interface with inline expandable editing for Directus. Provides reusable ItemSelector components for other extensions.",
   "author": "Christopher Schwarz <christopher@neugebauerschwarz.com>",
   "license": "MIT",

--- a/src/composables/useBlockActions.ts
+++ b/src/composables/useBlockActions.ts
@@ -798,37 +798,64 @@ export function useBlockActions(ctx: ExpandableBlocksContext) {
    */
   function addExistingItems(collection: string, selectedItems: ItemRecord[]): void {
     if (props.disabled) return;
-    
+
     if (!isValidPrimaryKey(props.primaryKey)) {
       notifyWarning('Save Required', 'Please save the item first before adding blocks.');
       return;
     }
-    
+
     if (!selectedItems || selectedItems.length === 0) {
       return;
     }
-    
+
+    // Filter out items already linked in this record for the same collection
+    const alreadyLinkedIds = new Set(
+      items.value
+        .filter(i => i.collection === collection && i.item)
+        .map(i => {
+          const itemData = i.item;
+          return typeof itemData === 'object' && itemData !== null
+            ? String((itemData as ItemRecord).id)
+            : String(itemData);
+        })
+        .filter(Boolean)
+    );
+
+    const uniqueItems = selectedItems.filter(item => !alreadyLinkedIds.has(String(item.id)));
+    const skipped = selectedItems.length - uniqueItems.length;
+
+    if (skipped > 0) {
+      notifyWarning('Duplicates Skipped', `${skipped} item(s) already linked, skipped.`);
+    }
+
+    if (uniqueItems.length === 0) {
+      return;
+    }
+
     logAction('addExistingItems', {
       collection,
-      itemCount: selectedItems.length,
-      itemIds: selectedItems.map(item => item.id)
+      itemCount: uniqueItems.length,
+      itemIds: uniqueItems.map(item => item.id),
+      skippedDuplicates: skipped
     });
-    
+
     // Create junction entries using helper
-    const newJunctionEntries = createJunctionEntries(collection, selectedItems, {
+    const newJunctionEntries = createJunctionEntries(collection, uniqueItems, {
       idPrefix: 'existing_'
     });
-    
+
     // Add items to list and emit changes
     addItemsToList(newJunctionEntries, 'ADD EXISTING - addExistingItems', {
       function: 'addExistingItems',
       collection: collection,
-      addedCount: selectedItems.length
+      addedCount: uniqueItems.length,
+      skippedDuplicates: skipped
     });
-    
+
     logDebug('Added existing items', {
       collection,
-      count: selectedItems.length,
+      count: uniqueItems.length,
+      skipped,
       totalItems: items.value.length
     });
   }

--- a/src/composables/useBlockState.ts
+++ b/src/composables/useBlockState.ts
@@ -1,8 +1,8 @@
 import { ref, computed, type Ref } from 'vue';
 import { logger } from '../utils/logger-wrapper';
 import { deepClone, deepEqual } from '../utils/helpers';
-import { isTemporaryId } from '../utils/validation';
-import type { JunctionRecord } from '../types';
+import { isTemporaryId, isExistingLink } from '../utils/validation';
+import type { JunctionRecord, ItemRecord } from '../types';
 
 /**
  * Composable for managing block state in the expandable blocks extension
@@ -213,23 +213,26 @@ export function useBlockState(_relationInfo?: Ref<any>) {
         }
       }
       
-      // New block - always emit full object
-      logger.debug(`Emitting full object for new block at index ${index}`);
-      debugInfo['items'].push({
-        index,
-        blockId: 'NEW',
-        isDirty: true,
-        isNew: true
-      });
-      
-      // Create a copy without the temporary ID
-      const { id: _id, ...itemWithoutId } = item;
-      
-      // If sort field exists, ensure it's set
-      if (sortField) {
-        itemWithoutId[sortField] = index;
+      // New block handling
+      const isLink = isExistingLink(item.id);
+
+      if (isLink && item.item && typeof item.item === 'object' && item.item !== null && 'id' in item.item) {
+        // Linked existing item: emit bare PK to avoid writing/mutating the source item
+        logger.debug(`Emitting bare PK reference for linked existing block at index ${index}`);
+        debugInfo['items'].push({ index, blockId: 'LINK', isDirty: false, isNew: true });
+
+        const { id: _id, ...itemWithoutId } = item;
+        itemWithoutId.item = (item.item as ItemRecord).id; // bare PK only
+        if (sortField) { itemWithoutId[sortField] = index; }
+        return itemWithoutId;
       }
-      
+
+      // Truly new block: emit full object without the temporary wrapper ID
+      logger.debug(`Emitting full object for new block at index ${index}`);
+      debugInfo['items'].push({ index, blockId: 'NEW', isDirty: true, isNew: true });
+
+      const { id: _id, ...itemWithoutId } = item;
+      if (sortField) { itemWithoutId[sortField] = index; }
       return itemWithoutId;
     });
 

--- a/src/composables/useM2AData.ts
+++ b/src/composables/useM2AData.ts
@@ -194,8 +194,8 @@ export function useM2AData(
         }));
       }
     } else {
-      // If not specified, no collections are allowed for existing blocks
-      allowedCollectionsForExisting.value = [];
+      // Fallback: use the same collections as allowedCollections (as documented in option note)
+      allowedCollectionsForExisting.value = [...allowedCollections.value];
     }
   }
 

--- a/src/types/composable-context.ts
+++ b/src/types/composable-context.ts
@@ -1,7 +1,8 @@
 import type { Ref, ComputedRef } from 'vue';
-import type { 
-  JunctionRecord, 
-  UseExpandableBlocksProps, 
+import type {
+  JunctionRecord,
+  CollectionInfo,
+  UseExpandableBlocksProps,
   ExpandableBlocksOptions,
   DirectusFormValues,
   M2AFieldInfo
@@ -73,8 +74,8 @@ export interface BlockUIContext {
  */
 export interface BlockDataContext {
   relationInfo: Ref<any>;
-  allowedCollections: Ref<any[]>;
-  allowedCollectionsForExisting: Ref<any[]>;
+  allowedCollections: Ref<CollectionInfo[]>;
+  allowedCollectionsForExisting: Ref<CollectionInfo[]>;
   m2aStructure: Ref<M2AFieldInfo | null>;
   values: Ref<DirectusFormValues>;
   initialValues: Ref<DirectusFormValues>;

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -24,6 +24,8 @@ export interface ItemRecord {
 export interface CollectionInfo {
   collection: string;
   name: string;
+  icon?: string;
+  singleton?: boolean;
   meta?: {
     icon?: string;
     [key: string]: any;

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -44,6 +44,16 @@ export function isTemporaryId(id: string | number | undefined): boolean {
 }
 
 /**
+ * Check if an ID represents a linked existing item (not a truly new item)
+ * @param id - The ID to check
+ * @returns true if the ID was created by addExistingItems (existing_ prefix)
+ */
+export function isExistingLink(id: string | number | undefined): boolean {
+  if (!id) return false;
+  return String(id).startsWith('existing_');
+}
+
+/**
  * Validate that a collection name is provided
  * @param collection - The collection name to validate
  * @returns true if collection name is valid

--- a/test/unit/composables/useBlockActions.spec.ts
+++ b/test/unit/composables/useBlockActions.spec.ts
@@ -358,10 +358,64 @@ describe('useBlockActions', () => {
   describe('onSort', () => {
     it('emits changes after sort', () => {
       const actions = useBlockActions(ctx);
-      
+
       actions.onSort();
-      
+
       expect(vi.mocked(emitChanges)).toHaveBeenCalled();
+    });
+  });
+
+  describe('addExistingItems', () => {
+    it('filters out items that are already linked in the current record', () => {
+      ctx.state.items = ref([
+        { id: 10, collection: 'content_text', item: { id: 42, title: 'Existing' } }
+      ]);
+      ctx.deps.props.primaryKey = 123;
+      ctx.deps.props.disabled = false;
+
+      const actions = useBlockActions(ctx);
+
+      actions.addExistingItems('content_text', [
+        { id: 42, title: 'Existing' },
+        { id: 99, title: 'Brand New' }
+      ]);
+
+      expect(ctx.state.items.value).toHaveLength(2);
+      const newItem = ctx.state.items.value.find((i) => i.collection === 'content_text' && i.item?.id === 99);
+      expect(newItem).toBeDefined();
+      expect(newItem?.item?.id).toBe(99);
+    });
+
+    it('skips all items if all are already linked', () => {
+      ctx.state.items = ref([
+        { id: 10, collection: 'content_text', item: { id: 42, title: 'Existing' } }
+      ]);
+      ctx.deps.props.primaryKey = 123;
+      ctx.deps.props.disabled = false;
+
+      const actions = useBlockActions(ctx);
+
+      actions.addExistingItems('content_text', [
+        { id: 42, title: 'Existing' }
+      ]);
+
+      expect(ctx.state.items.value).toHaveLength(1);
+    });
+
+    it('allows linking the same item to different collections', () => {
+      ctx.state.items = ref([
+        { id: 10, collection: 'content_text', item: { id: 42, title: 'As Text' } }
+      ]);
+      ctx.deps.props.primaryKey = 123;
+      ctx.deps.props.disabled = false;
+
+      const actions = useBlockActions(ctx);
+
+      actions.addExistingItems('content_image', [
+        { id: 42, title: 'As Image' }
+      ]);
+
+      expect(ctx.state.items.value).toHaveLength(2);
     });
   });
 });

--- a/test/unit/composables/useBlockState.spec.ts
+++ b/test/unit/composables/useBlockState.spec.ts
@@ -44,7 +44,8 @@ vi.mock('@/utils/helpers', () => ({
 }));
 
 vi.mock('@/utils/validation', () => ({
-  isTemporaryId: vi.fn((id) => typeof id === 'string' && (id.startsWith('new_') || id.startsWith('dup_') || id.startsWith('temp_')))
+  isTemporaryId: vi.fn((id) => typeof id === 'string' && (id.startsWith('new_') || id.startsWith('dup_') || id.startsWith('temp_') || id.startsWith('existing_'))),
+  isExistingLink: vi.fn((id) => typeof id === 'string' && id.startsWith('existing_'))
 }));
 
 describe('useBlockState', () => {
@@ -205,22 +206,61 @@ describe('useBlockState', () => {
   describe('State Persistence', () => {
     it('maintains separate state for each block', () => {
       const state = useBlockState(relationInfo);
-      
+
       state.blockOriginalStates.value.set('1', { title: 'Block 1' });
       state.blockOriginalStates.value.set('2', { title: 'Block 2' });
-      
+
       expect(state.blockOriginalStates.value.get('1')).toEqual({ title: 'Block 1' });
       expect(state.blockOriginalStates.value.get('2')).toEqual({ title: 'Block 2' });
     });
 
     it('can remove block state', () => {
       const state = useBlockState(relationInfo);
-      
+
       state.blockOriginalStates.value.set('123', { title: 'Test' });
       expect(state.blockOriginalStates.value.has('123')).toBe(true);
-      
+
       state.removeBlockState('123');
       expect(state.blockOriginalStates.value.has('123')).toBe(false);
+    });
+  });
+
+  describe('prepareItemsForEmit', () => {
+    it('emits bare PK for linked existing items (existing_ prefix)', () => {
+      const { items, prepareItemsForEmit } = useBlockState(relationInfo);
+
+      const linkedItem = {
+        id: 'existing_1234_0',
+        collection: 'content_text',
+        item: { id: 42, title: 'Original Title', status: 'published' }
+      };
+
+      items.value = [linkedItem];
+
+      const result = prepareItemsForEmit(items.value, 'sort');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].item).toBe(42); // bare PK, not full object
+      expect(result[0].collection).toBe('content_text');
+      expect(typeof result[0].item).toBe('number');
+    });
+
+    it('emits full object for truly new items (new_ prefix)', () => {
+      const { items, prepareItemsForEmit } = useBlockState(relationInfo);
+
+      const newItem = {
+        id: 'new_1234',
+        collection: 'content_text',
+        item: { title: 'New Block' }
+      };
+
+      items.value = [newItem];
+
+      const result = prepareItemsForEmit(items.value, 'sort');
+
+      expect(result).toHaveLength(1);
+      expect(result[0].item).toEqual({ title: 'New Block' });
+      expect(typeof result[0].item).toBe('object');
     });
   });
 });

--- a/test/unit/composables/useM2AData.spec.ts
+++ b/test/unit/composables/useM2AData.spec.ts
@@ -511,15 +511,55 @@ describe('useM2AData', () => {
         { collection: 'content_image', name: 'Image', icon: 'image' },
         { collection: 'content_hero', name: 'Hero', icon: 'star' }
       ];
-      
+
       const m2aData = useM2AData(ctx, updateOriginalItemOrder, clearStateTracking);
-      
+
       const map = m2aData.allowedCollectionsMap.value;
       expect(map).toHaveProperty('content_text');
       expect(map).toHaveProperty('content_image');
       expect(map).toHaveProperty('content_hero');
-      
+
       expect(map.content_text.collection).toBe('content_text');
+    });
+  });
+
+  describe('loadAllowedCollectionsForExisting', () => {
+    it('falls back to allowedCollections when allowedCollectionsForExisting is empty', async () => {
+      ctx.data.allowedCollectionsForExisting = ref([]);
+      ctx.deps.stores.collectionsStore = {
+        getCollection: vi.fn().mockReturnValue({
+          name: 'Content Text',
+          meta: { icon: 'article', singleton: false }
+        })
+      };
+      ctx.data.allowedCollections.value = [
+        { collection: 'content_text', name: 'Content Text', icon: 'article', singleton: false },
+        { collection: 'content_image', name: 'Content Image', icon: 'image', singleton: false }
+      ];
+      ctx.ui.mergedOptions.value = { allowedCollections: ['content_text', 'content_image'] };
+
+      const m2aData = useM2AData(ctx, updateOriginalItemOrder, clearStateTracking);
+      await m2aData.loadAllowedCollectionsForExisting();
+
+      expect(ctx.data.allowedCollectionsForExisting.value).toHaveLength(2);
+      expect(ctx.data.allowedCollectionsForExisting.value[0].collection).toBe('content_text');
+    });
+
+    it('uses explicit allowedCollectionsForExisting when provided', async () => {
+      ctx.data.allowedCollectionsForExisting = ref([]);
+      ctx.deps.stores.collectionsStore = {
+        getCollection: vi.fn().mockReturnValue({
+          name: 'Content Text',
+          meta: { icon: 'article', singleton: false }
+        })
+      };
+      ctx.ui.mergedOptions.value = { allowedCollectionsForExisting: ['content_text'] };
+
+      const m2aData = useM2AData(ctx, updateOriginalItemOrder, clearStateTracking);
+      await m2aData.loadAllowedCollectionsForExisting();
+
+      expect(ctx.data.allowedCollectionsForExisting.value).toHaveLength(1);
+      expect(ctx.data.allowedCollectionsForExisting.value[0].collection).toBe('content_text');
     });
   });
 });

--- a/test/unit/utils/validation.spec.ts
+++ b/test/unit/utils/validation.spec.ts
@@ -4,6 +4,7 @@ import {
   isItemObject,
   isNotNullish,
   isTemporaryId,
+  isExistingLink,
   isValidCollection,
   isValidM2AField
 } from '../../../src/utils/validation';
@@ -149,6 +150,28 @@ describe('validation', () => {
       expect(isTemporaryId('NEW_123')).toBe(false);
       expect(isTemporaryId('TEMP_123')).toBe(false);
       expect(isTemporaryId('DUP_123')).toBe(false);
+    });
+  });
+
+  describe('isExistingLink', () => {
+    it('returns true for existing_ prefixed IDs', () => {
+      expect(isExistingLink('existing_1234_0')).toBe(true);
+      expect(isExistingLink('existing_5678_1')).toBe(true);
+    });
+
+    it('returns false for other temporary IDs', () => {
+      expect(isExistingLink('new_1234')).toBe(false);
+      expect(isExistingLink('dup_1234')).toBe(false);
+      expect(isExistingLink('temp_1234')).toBe(false);
+    });
+
+    it('returns false for real IDs', () => {
+      expect(isExistingLink(42)).toBe(false);
+      expect(isExistingLink('abc-uuid')).toBe(false);
+    });
+
+    it('returns false for undefined/null', () => {
+      expect(isExistingLink(undefined)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes three bugs in the "Add Existing" feature, all verified end-to-end against a running Directus instance.

### Bug #1 — Empty config hides button (Fixes #65)
`allowedCollectionsForExisting` empty/unset hid the "Add Existing" button entirely. The option note promises fallback to "Allowed Collections" — now it does.

### Bug #2 — Link mutates source item
Linking an existing item emitted the full nested object (incl. PK + all fields). Directus treated this as an upsert, writing back to the source on every save. Now emits a bare PK reference.

### Bug #3 — No de-duplication
Same item could be linked multiple times, creating duplicate junction rows. Now filters already-linked IDs and notifies the user.

### Additional
- `allowedCollections` / `allowedCollectionsForExisting` refs typed as `CollectionInfo[]` instead of `any[]`
- Fixed wrong option name in README (`allowedCollectionsExisting` → `allowedCollectionsForExisting`)

## Tests
- 514 unit tests pass, 0 failures
- TypeScript type-check clean
- E2E verified in browser (Playwright) against live Directus instance

## Commits
- `7108829` fix: fall back to allowedCollections when allowedCollectionsForExisting is empty
- `8bd95bf` fix: emit bare PK for linked existing items to prevent source mutation
- `af5dfbf` fix: prevent duplicate links when adding existing items
- `e70e241` refactor: type allowedCollections refs as CollectionInfo[] instead of any[]
- `8ca299d` chore: bump version to 1.3.6
- `0c1d658` docs: add 1.3.6 changelog, fix option name in README